### PR TITLE
Set account to profile after a successful login

### DIFF
--- a/FxAUtils/FxALoginHelper.swift
+++ b/FxAUtils/FxALoginHelper.swift
@@ -157,7 +157,7 @@ open class FxALoginHelper {
         if AppConstants.MOZ_FXA_PUSH {
             requestUserNotifications(application)
         } else {
-            loginDidSucceed()
+            readyForSyncing()
         }
     }
 


### PR DESCRIPTION
This PR is a fixup for a stupid bug introduced in #2.

When Push is disabled, `readyForSyncing` should be called immediately, which is the final method to be called to complete the login.

It also starts the sync, or waits for the user to email verify, and then starts the sync.

The bug was that `loginDidSucceed` — the method intended to inform the outside world/delegates that the login was successful.