### PR TITLE
Workround account race condition.

### DIFF
--- a/FxAUtils/FxALoginHelper.swift
+++ b/FxAUtils/FxALoginHelper.swift
@@ -150,7 +150,7 @@ open class FxALoginHelper {
         accountVerified = data["verified"].bool ?? false
         self.account = account
 
-        account.updateProfile()
+        _ = account.updateProfile()
 
         if AppConstants.MOZ_FXA_PUSH {
             requestUserNotifications(application)
@@ -307,8 +307,8 @@ open class FxALoginHelper {
     }
 
     func performVerifiedSync(_ profile: Profile, account: FirefoxAccount) {
-        profile.syncManager.syncEverything(why: .didLogin).uponQueue(.main) { _ in
-//            self.delegate?.accountDidSync()
+        profile.syncManager.syncEverything(why: .didLogin) >>== {
+            _ = account.updateProfile()
         }
     }
 }

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -52,4 +52,6 @@ public struct AppConstants {
     }()
 
     public static let PrefSendUsageData = "pref.sendUsageData"
+
+    public static let FxADeviceRegistrationEnabled = false
 }


### PR DESCRIPTION
This PR does a number of things, but only one fixes the issue:

 * disables registration of devices. This is a good thing, as we're unable to send tabs, disconnect remotely or send push messages to.
 * changes `account.updateProfile()` to return a `Deferred<Maybe<FxAProfile>>`. This lets it be sequenced with other async methods.
 * adds a second `account.updateProfile()` in the `FxALoginHelper` to be done immediately after the initial sync.