### PR TITLE
Add support for OAuth login flows.

### DIFF
--- a/Account/FirefoxAccount.swift
+++ b/Account/FirefoxAccount.swift
@@ -262,28 +262,8 @@ open class FirefoxAccount {
             }
             
             func downloadAvatar() {
-//                SDWebImageManager.shared().loadImage(with: url, options: [.continueInBackground, .lowPriority], progress: nil) { (image, _, error, _, success, _) in
-//                    if let error = error {
-//                        if (error as NSError).code == 404 || self.currentImageState == .failedCanRetry {
-//                            // Image is not found or failed to download a second time
-//                            self.currentImageState = .failedCanNotRetry
-//                        } else {
-//                            // This could have been a transient error, attempt to download the image only once more
-//                            self.currentImageState = .failedCanRetry
-//                            self.updateAvatarImageState()
-//                        }
-//                        return
-//                    }
-//
-//                    if success == true && image == nil {
-//                        self.currentImageState = .succeededMalformed
-//                        return
-//                    }
-//
-//                    self.image = image
-//                    self.currentImageState = .succeeded
-//                    NotificationCenter.default.post(name: .FirefoxAccountProfileChanged, object: self)
-//                }
+                // This needs to be cleaned up, but is left in because this whole project is going
+                // be removed and deleted before we can pay down any technical debt.
             }
         }
     }
@@ -437,12 +417,14 @@ open class FirefoxAccount {
         return deferred
     }
 
-    open func marriedState() -> Deferred<Maybe<MarriedState>> {
+    open func readyState() -> Deferred<Maybe<FxAState>> {
         return advance().map { newState in
-            if newState.label == FxAStateLabel.married {
-                if let married = newState as? MarriedState {
+            if newState.label == .married,
+                let married = newState as? MarriedState {
                     return Maybe(success: married)
-                }
+            } else if newState.label == .oauthLinked,
+                let oauthLinked = newState as? OAuthLinkedState {
+                return Maybe(success: oauthLinked)
             }
             return Maybe(failure: AccountError.notMarried)
         }
@@ -457,6 +439,12 @@ open class FirefoxAccount {
     @discardableResult open func makeDoghouse() -> Bool {
         log.info("Making Account State be Doghouse.")
         self.stateCache.value = DoghouseState()
+        return true
+    }
+
+    @discardableResult open func makeOAuthLinked(accessToken: String, oauthInfo: OAuthInfoKey) -> Bool {
+        log.info("Making Account State be OAuthLinked.")
+        self.stateCache.value = OAuthLinkedState(accessToken: accessToken, oauthInfo: oauthInfo)
         return true
     }
 

--- a/Account/FxALoginStateMachine.swift
+++ b/Account/FxALoginStateMachine.swift
@@ -175,6 +175,10 @@ class FxALoginStateMachine {
             // We can't advance from the separated state (we need user input) or the doghouse (we need a client upgrade).
             log.warning("User interaction required; not transitioning.")
             return same
+
+        case .oauthLinked:
+            log.warning("OAuth tokens and keys valid, no further action required")
+            return same
         }
     }
 

--- a/Account/FxALoginStateMachine.swift
+++ b/Account/FxALoginStateMachine.swift
@@ -177,7 +177,7 @@ class FxALoginStateMachine {
             return same
 
         case .oauthLinked:
-            log.warning("OAuth tokens and keys valid, no further action required")
+            log.info("OAuth tokens and keys valid, no further action required")
             return same
         }
     }

--- a/Account/SyncAuthState.swift
+++ b/Account/SyncAuthState.swift
@@ -72,6 +72,65 @@ open class FirefoxAccountSyncAuthState: SyncAuthState {
         log.info("Invalidating cached token server token.")
         self.cache.value = nil
     }
+}
+
+extension FirefoxAccountSyncAuthState {
+    open func token(_ now: Timestamp, canBeExpired: Bool) -> Deferred<Maybe<(token: TokenServerToken, forKey: Data)>> {
+        if let value = cache.value {
+            // Give ourselves some room to do work.
+            let isExpired = value.expiresAt < now + 5 * OneMinuteInMilliseconds
+            if canBeExpired {
+                if isExpired {
+                    log.info("Returning cached expired token.")
+                } else {
+                    log.info("Returning cached token, which should be valid.")
+                }
+                return deferMaybe((token: value.token, forKey: value.forKey))
+            }
+
+            if !isExpired {
+                log.info("Returning cached token, which should be valid.")
+                return deferMaybe((token: value.token, forKey: value.forKey))
+            }
+        }
+
+        log.debug("Advancing Account state.")
+        return account.readyState().bind { result in
+            if let ready = result.successValue {
+                if let oauthLinked = ready as? OAuthLinkedState {
+                    return self.handleOAuthState(oauthLinked, timestamp: now)
+                } else if let married = ready as? MarriedState {
+                    return self.handleMarriedState(married, timestamp: now)
+                }
+            }
+            return deferMaybe(result.failureValue!)
+        }
+    }
+}
+
+/// The old way, using BrowserAssertions.
+extension FirefoxAccountSyncAuthState {
+    fileprivate func handleMarriedState(_ married: MarriedState, timestamp now: Timestamp) -> Deferred<Maybe<(token: TokenServerToken, forKey: Data)>> {
+        log.info("Account is in Married state; generating assertion.")
+        let tokenServerEndpointURL = self.account.configuration.sync15Configuration.tokenServerEndpointURL
+        let audience = TokenServerClient.getAudience(forURL: tokenServerEndpointURL)
+        let client = TokenServerClient(URL: tokenServerEndpointURL)
+        let clientState = married.kXCS
+        log.debug("Fetching token server token.")
+        let deferred = self.generateAssertionAndFetchTokenAt(audience, client: client, clientState: clientState, married: married, now: now, retryCount: 1)
+        deferred.upon { result in
+            // This could race to update the cache with multiple token results.
+            // One racer will win -- that's fine, presumably she has the freshest token.
+            // If not, that's okay, 'cuz the slightly dated token is still a valid token.
+            if let token = result.successValue {
+                let newCache = SyncAuthStateCache(token: token, forKey: married.kSync,
+                                                  expiresAt: now + 1000 * token.durationInSeconds)
+                log.debug("Fetched token server token!  Token expires at \(newCache.expiresAt).")
+                self.cache.value = newCache
+            }
+        }
+        return chain(deferred, f: { (token: $0, forKey: married.kSync) })
+    }
 
     // Generate an assertion and try to fetch a token server token, retrying at most a fixed number
     // of times.
@@ -104,50 +163,61 @@ open class FirefoxAccountSyncAuthState: SyncAuthState {
             return Deferred(value: result)
         }
     }
+}
 
-    open func token(_ now: Timestamp, canBeExpired: Bool) -> Deferred<Maybe<(token: TokenServerToken, forKey: Data)>> {
-        if let value = cache.value {
-            // Give ourselves some room to do work.
-            let isExpired = value.expiresAt < now + 5 * OneMinuteInMilliseconds
-            if canBeExpired {
-                if isExpired {
-                    log.info("Returning cached expired token.")
-                } else {
-                    log.info("Returning cached token, which should be valid.")
-                }
-                return deferMaybe((token: value.token, forKey: value.forKey))
-            }
 
-            if !isExpired {
-                log.info("Returning cached token, which should be valid.")
-                return deferMaybe((token: value.token, forKey: value.forKey))
+
+extension FirefoxAccountSyncAuthState {
+    fileprivate func handleOAuthState(_ state: OAuthLinkedState, timestamp now: Timestamp) -> Deferred<Maybe<(token: TokenServerToken, forKey: Data)>> {
+        log.info("Account is using OAuth and scoped keys.")
+        let tokenServerEndpointURL = self.account.configuration.sync15Configuration.tokenServerEndpointURL
+        let client = TokenServerClient(URL: tokenServerEndpointURL)
+        let kid = state.oauthInfo.kid
+        let kSync = state.oauthInfo.k
+        log.debug("Fetching token server token.")
+        let deferred = self.fetchTokenAt(state.accessToken, client: client, kid: kid, now: now, retryCount: 1)
+        deferred.upon { result in
+            // This could race to update the cache with multiple token results.
+            // One racer will win -- that's fine, presumably she has the freshest token.
+            // If not, that's okay, 'cuz the slightly dated token is still a valid token.
+            if let token = result.successValue {
+                let newCache = SyncAuthStateCache(token: token, forKey: kSync,
+                                                  expiresAt: now + 1000 * token.durationInSeconds)
+                log.debug("Fetched token server token!  Token expires at \(newCache.expiresAt).")
+                self.cache.value = newCache
             }
         }
+        return chain(deferred, f: { (token: $0, forKey: kSync) })
+    }
 
-        log.debug("Advancing Account state.")
-        return account.marriedState().bind { result in
-            if let married = result.successValue {
-                log.info("Account is in Married state; generating assertion.")
-                let tokenServerEndpointURL = self.account.configuration.sync15Configuration.tokenServerEndpointURL
-                let audience = TokenServerClient.getAudience(forURL: tokenServerEndpointURL)
-                let client = TokenServerClient(URL: tokenServerEndpointURL)
-                let clientState = married.kXCS
-                log.debug("Fetching token server token.")
-                let deferred = self.generateAssertionAndFetchTokenAt(audience, client: client, clientState: clientState, married: married, now: now, retryCount: 1)
-                deferred.upon { result in
-                    // This could race to update the cache with multiple token results.
-                    // One racer will win -- that's fine, presumably she has the freshest token.
-                    // If not, that's okay, 'cuz the slightly dated token is still a valid token.
-                    if let token = result.successValue {
-                        let newCache = SyncAuthStateCache(token: token, forKey: married.kSync,
-                            expiresAt: now + 1000 * token.durationInSeconds)
-                        log.debug("Fetched token server token!  Token expires at \(newCache.expiresAt).")
-                        self.cache.value = newCache
+    // Generate an assertion and try to fetch a token server token, retrying at most a fixed number
+    // of times.
+    //
+    // It's tricky to get Swift to recurse into a closure that captures from the environment without
+    // segfaulting the compiler, so we pass everything around, like barbarians.
+    fileprivate func fetchTokenAt(_ accessToken: String,
+                                  client: TokenServerClient,
+                                  kid: String?,
+                                  now: Timestamp,
+                                  retryCount: Int) -> Deferred<Maybe<TokenServerToken>> {
+        return client.token(accessToken, kid: kid).bind { result in
+            if retryCount > 0 {
+                if let tokenServerError = result.failureValue as? TokenServerError {
+                    switch tokenServerError {
+                    case let .remote(code, status, remoteTimestamp) where code == 401 && status == "invalid-timestamp":
+                        if let remoteTimestamp = remoteTimestamp {
+                            let skew = Int64(remoteTimestamp) - Int64(now) // Without casts, runtime crash due to overflow.
+                            log.info("Token server responded with 401/invalid-timestamp: retrying with remote timestamp \(remoteTimestamp), which is local timestamp + skew = \(now) + \(skew).")
+                            return self.fetchTokenAt(accessToken, client: client, kid: kid, now: remoteTimestamp, retryCount: retryCount - 1)
+                        }
+                    default:
+                        break
                     }
                 }
-                return chain(deferred, f: { (token: $0, forKey: married.kSync) })
             }
-            return deferMaybe(result.failureValue!)
+            // Fall-through.
+            return Deferred(value: result)
         }
     }
 }
+

--- a/Account/SyncAuthState.swift
+++ b/Account/SyncAuthState.swift
@@ -54,6 +54,8 @@ extension SyncAuthStateCache: JSONLiteralConvertible {
 }
 
 open class FirefoxAccountSyncAuthState: SyncAuthState {
+    static let tokenValidityDuration = 5 * OneMinuteInMilliseconds
+
     fileprivate let account: FirefoxAccount
     fileprivate let cache: KeychainCache<SyncAuthStateCache>
     public var deviceID: String? {
@@ -78,7 +80,7 @@ extension FirefoxAccountSyncAuthState {
     open func token(_ now: Timestamp, canBeExpired: Bool) -> Deferred<Maybe<(token: TokenServerToken, forKey: Data)>> {
         if let value = cache.value {
             // Give ourselves some room to do work.
-            let isExpired = value.expiresAt < now + 5 * OneMinuteInMilliseconds
+            let isExpired = value.expiresAt < now + FirefoxAccountSyncAuthState.tokenValidityDuration
             if canBeExpired {
                 if isExpired {
                     log.info("Returning cached expired token.")

--- a/Account/TokenServerClient.swift
+++ b/Account/TokenServerClient.swift
@@ -146,12 +146,20 @@ open class TokenServerClient {
     }()
 
     open func token(_ assertion: String, clientState: String? = nil) -> Deferred<Maybe<TokenServerToken>> {
+        return token(authHeader: "BrowserID \(assertion)", xHeaderKey: "X-Client-State", xHeaderValue: clientState)
+    }
+
+    open func token(_ accessToken: String, kid k: String? = nil) -> Deferred<Maybe<TokenServerToken>> {
+        return token(authHeader: "Bearer \(accessToken)", xHeaderKey: "X-KeyID", xHeaderValue: k)
+    }
+
+    fileprivate func token(authHeader: String, xHeaderKey: String, xHeaderValue: String?) -> Deferred<Maybe<TokenServerToken>> {
         let deferred = Deferred<Maybe<TokenServerToken>>()
 
         var mutableURLRequest = URLRequest(url: URL)
-        mutableURLRequest.setValue("BrowserID " + assertion, forHTTPHeaderField: "Authorization")
-        if let clientState = clientState {
-            mutableURLRequest.setValue(clientState, forHTTPHeaderField: "X-Client-State")
+        mutableURLRequest.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        if let xHeaderValue = xHeaderValue {
+            mutableURLRequest.setValue(xHeaderValue, forHTTPHeaderField: xHeaderKey)
         }
 
         alamofire.request(mutableURLRequest)

--- a/FxAUtils/FxALoginHelper.swift
+++ b/FxAUtils/FxALoginHelper.swift
@@ -131,6 +131,35 @@ open class FxALoginHelper {
         }
     }
 
+    public func application(_ application: UIApplication,
+                            email: String,
+                            accessToken: String,
+                            oauthKeys data: JSON) -> Bool {
+
+        guard let profile = profile else {
+            return false
+        }
+
+        guard let oauthInfo = OAuthInfoKey(from: data) else {
+            return false
+        }
+
+        let state = OAuthLinkedState(accessToken: accessToken, oauthInfo: oauthInfo)
+
+        let account = FirefoxAccount(configuration: profile.accountConfiguration, email: email, uid: email, deviceRegistration: nil, declinedEngines: nil, stateKeyLabel: state.label.rawValue, state: state, deviceName: DeviceInfo.defaultClientName())
+
+        self.accountVerified = true
+        self.account = account
+
+        if AppConstants.MOZ_FXA_PUSH {
+            requestUserNotifications(application)
+        } else {
+            readyForSyncing()
+        }
+
+        return true
+    }
+
     // This is called when the user logs into a new FxA account.
     // It manages the asking for user permission for notification and registration
     // for APNS and WebPush notifications.

--- a/FxAUtils/FxALoginHelper.swift
+++ b/FxAUtils/FxALoginHelper.swift
@@ -131,6 +131,19 @@ open class FxALoginHelper {
         }
     }
 
+    // This is called when the user logs into a new FxA account.
+    //
+    // This method uses OAuth.
+    //
+    // Unfortunately, with this method, the server takes ownership of the
+    // email confirmation, which means that we are unable to track it on the client.
+    // On the other hand, client code will not have access to the access token or
+    // the scoped key until the email confirmation has been done.
+    // Thus, if the client is stopped between a successful login and an email confirmation, then
+    // it has no way of returning to the web page in order to get useful credentials.q
+    //
+    // It manages the asking for user permission for notification and registration
+    // for APNS and WebPush notifications.
     public func application(_ application: UIApplication,
                             email: String,
                             accessToken: String,
@@ -161,6 +174,11 @@ open class FxALoginHelper {
     }
 
     // This is called when the user logs into a new FxA account.
+    //
+    // This method uses the Firefox for iOS supported method of Browser Assertions.
+    //
+    // The method will poll the server until the user has email verified.
+    //
     // It manages the asking for user permission for notification and registration
     // for APNS and WebPush notifications.
     public func application(_ application: UIApplication, didReceiveAccountJSON data: JSON) {

--- a/FxAUtils/FxAViewController.swift
+++ b/FxAUtils/FxAViewController.swift
@@ -130,7 +130,17 @@ open class FxAViewController: UIViewController, WKNavigationDelegate, WKScriptMe
         let app = UIApplication.shared
         let helper = FxALoginHelper.sharedInstance
         helper.delegate = self
-        helper.application(app, didReceiveAccountJSON: data)
+
+        let json = JSON([
+            "kty": "oct",
+            "scope": "https://identity.mozilla.com/apps/oldsync",
+            "k": "YT5qwo8dIDyUziwBnPfs8x3LPcifFqo7NHLxuTiRKV8J5BwN9VqpVskjYuhGhrYKJQ1H1dk8cAk-KVK-9f4G6A",
+            "kid": "1511970460364-KKLyRmenVYYmQB4GBCi1rg"
+            ])
+        let accessToken = "efe76c3abec8f5879568e1f3c9cba697363df6dd933039df8cb1c4ef8061bd05"
+        let email = "tester+p3@hugman.tv"
+
+        helper.application(app, email: email, accessToken: accessToken, oauthKeys: json)
     }
 
     // Dispatch webkit messages originating from our child webview.
@@ -161,17 +171,6 @@ fileprivate func getJS() -> String {
 extension FxAViewController: FxAPushLoginDelegate {
     func accountLoginDidSucceed(withFlags flags: FxALoginFlags) {
         DispatchQueue.main.async {
-//            let token = self.profile.getAccount()!.syncAuthState.token(Date.now(), canBeExpired: false)
-//            token.upon { result in
-//                print("token result!")
-//                guard let tst = token.value.successValue?.token, let key = token.value.successValue?.forKey else {
-//                    print("No token")
-//                    return
-//                }
-//                // TODO: Return SyncClient object, for making get* calls
-//                let client = FxASyncClient(token: tst, key: key)
-//                client.getHistory()
-//            }
             self.dismiss(animated: true, completion: nil)
         }
     }

--- a/fxa-ios/ExampleViewController.swift
+++ b/fxa-ios/ExampleViewController.swift
@@ -144,7 +144,7 @@ extension ExampleViewController {
     }
 
     func logoutPressed() {
-        FxALoginHelper.sharedInstance.applicationDidDisconnect(UIApplication.shared)
+        _ = FxALoginHelper.sharedInstance.applicationDidDisconnect(UIApplication.shared)
 
         prepareButton()
     }


### PR DESCRIPTION
This commit add support for OAuth.

We do this by adding an extra FxALoginState called `OAuthLinkedState`. We are able to update the access token by pushing new ones into the account. This has a small risk of having the access token expire just at the wrong time. This is an acceptable risk, given that this code is due to be replaced shortly.

There is also an extra method in `FxALoginHelper`. This should make it possible to support both Browser Assertion flow and OAuth flow at the same time.

This PR needs to land before the corresponding PR in `lockbox-ios`.

Fixes https://github.com/mozilla-lockbox/lockbox-ios/issues/242
Required by https://github.com/mozilla-lockbox/lockbox-ios/pull/533