### PR TITLE
Disallow ServerConfiguration

### DIFF
--- a/Sync/SyncStateMachine.swift
+++ b/Sync/SyncStateMachine.swift
@@ -104,9 +104,9 @@ open class SyncStateMachine {
     public static let OptimisticStates = Set(SyncStateLabel.optimisticValues)
 
     /// The default set of states that the state machine is allowed to use.
-    public static let AllStates = Set(SyncStateLabel.allValues)
+    public static let SupportedStates = Set(SyncStateLabel.supportedStates)
 
-    public init(prefs: Prefs, allowingStates labels: Set<SyncStateLabel> = SyncStateMachine.AllStates) {
+    public init(prefs: Prefs, allowingStates labels: Set<SyncStateLabel> = SyncStateMachine.SupportedStates) {
         self.scratchpadPrefs = prefs.branch("scratchpad")
         self.stateLabelsAllowed = labels
     }
@@ -258,6 +258,9 @@ public enum SyncStateLabel: String {
         HasFreshCryptoKeys,
         Ready,
     ]
+
+    static let supportedStates: [SyncStateLabel] =
+        SyncStateLabel.allValues.filter { ![ServerConfigurationRequired].contains($0) }
 }
 
 /**


### PR DESCRIPTION
This PR resolves https://github.com/mozilla-lockbox/lockbox-ios/issues/535.

The state is disallowed using the existing machinery that restricts the sync state machine.

If the state is reached a `DisallowedStateError` is bubbled up to `syncEverything()`.