### PR TITLE
Fix build under XCode 10.1

### DIFF
--- a/fxa-ios.xcodeproj/project.pbxproj
+++ b/fxa-ios.xcodeproj/project.pbxproj
@@ -83,7 +83,6 @@
 		23EDF0321E9EE74500F530CF /* FxALoginStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDF0251E9EE74500F530CF /* FxALoginStateMachine.swift */; };
 		23EDF0331E9EE74500F530CF /* FxAState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDF0261E9EE74500F530CF /* FxAState.swift */; };
 		23EDF0341E9EE74500F530CF /* HawkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDF0271E9EE74500F530CF /* HawkHelper.swift */; };
-		23EDF0351E9EE74500F530CF /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 23EDF0281E9EE74500F530CF /* Info.plist */; };
 		23EDF0361E9EE74500F530CF /* SyncAuthState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDF0291E9EE74500F530CF /* SyncAuthState.swift */; };
 		23EDF0371E9EE74500F530CF /* TokenServerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDF02A1E9EE74500F530CF /* TokenServerClient.swift */; };
 		23EDF03E1E9EE76800F530CF /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDF0391E9EE76800F530CF /* Logger.swift */; };
@@ -1205,7 +1204,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				23EDF0351E9EE74500F530CF /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
When building under XCode 10.1 the following error is produced:
```
Showing All Messages
Multiple commands produce '/Users/joe/Library/Developer/Xcode/DerivedData/fxa-ios-aiewqqeblhaqapcovxygwlgywrzp/Build/Products/Debug-iphonesimulator/Account.framework/Info.plist':
1) Target 'Account' (project 'fxa-ios') has copy command from '/Users/joe/dev/lockbox-ios-fxa-sync/Account/Info.plist' to '/Users/joe/Library/Developer/Xcode/DerivedData/fxa-ios-aiewqqeblhaqapcovxygwlgywrzp/Build/Products/Debug-iphonesimulator/Account.framework/Info.plist'
2) Target 'Account' (project 'fxa-ios') has process command with output '/Users/joe/Library/Developer/Xcode/DerivedData/fxa-ios-aiewqqeblhaqapcovxygwlgywrzp/Build/Products/Debug-iphonesimulator/Account.framework/Info.plist'
```

This appears to be the same fix as this commit: https://github.com/mozilla-lockbox/lockbox-ios-fxa-sync/commit/880f310086bac8ad16c81775b3235550d9ffc7f3